### PR TITLE
Deprecate CWLGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,45 @@
-# python-cwlgen
+# python-cwlgen (deprecated)
+
+## Deprecated
+
+`python-cwlgen` is now deprecated, please use [`cwl-utils >= 0.4`](https://github.com/common-workflow-language/cwl-utils).
+
+```sh
+from cwl_utils import parser_v1_0
+
+# You could alias this as cwlgen to simplify the migration
+from cwl_utils import parser_v1_0 as cwlgen
+```
+
+Migration notes:
+
+- Method changes
+  - `get_dict() → save()` 
+  - `parse_cwl(cwlfile)` → `load_document(cwlfile)`
+  - `parse_dict` → No super clear analogue, but loaded through `_RecordLoader(CommandLineTool)` || `_UnionLoader((CommandLineToolLoader, ...workflow + other loaders)`
+
+- Field names:
+  - Uses `camelCase` instead of `snake_case`
+  - No more special field names, eg:
+    - `tool_id` | `workflow_id` | `input_id` | etc → `id`
+    - `StepInput`: `inputs` → `in_`
+    
+- Other notes:
+  - Classes aren't nested anymore, ie: `cwlgen.InitialWorkDirRequirement.Dirent` → `cwlutils.
+  - Take care if you're migrating to a newer spec, as some classes might have changed names (notably: `InputParameter` -> `WorkflowInputParameter`)
+  - Don't forget to catch all references of cwlgen, as missing one will cause:
+  
+    ```python
+    raise RepresenterError('cannot represent an object: %s' % (data,))
+    ruamel.yaml.representer.RepresenterError: cannot represent an object: 
+    <cwlgen.common.CommandInputArraySchema object at 0x1100a5780>
+    ```
+    
+If you have issues with the migration, please see [this thread](https://github.com/common-workflow-language/python-cwlgen/issues/27) or raise an issue on CWLUtils.
+    
+---
+
+## Original README
 
 [![Build Status](https://travis-ci.org/common-workflow-language/python-cwlgen.svg?branch=master)](https://travis-ci.org/common-workflow-language/python-cwlgen)
 [![codecov](https://codecov.io/gh/common-workflow-language/python-cwlgen/branch/master/graph/badge.svg)](https://codecov.io/gh/common-workflow-language/python-cwlgen)
@@ -12,7 +53,7 @@ The library works for both Python 2.7.12+ and 3.6.0.
 ------------------------
 
 
-# Common Workflow Language
+## Common Workflow Language
 
 [Common Workflow Language (CWL)](https://www.commonwl.org/v1.0/index.html) is a language to describe workflows. 
 The [user guide](http://www.commonwl.org/user_guide/01-introduction/index.html)

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Migration notes:
     - `StepInput`: `inputs` → `in_`
     
 - Other notes:
-  - Classes aren't nested anymore, ie: `cwlgen.InitialWorkDirRequirement.Dirent` → `cwlutils.
+  - Classes aren't nested anymore, ie: `cwlgen.InitialWorkDirRequirement.Dirent` → `cwl_utils.parser_v1_0.Dirent`.
   - Take care if you're migrating to a newer spec, as some classes might have changed names (notably: `InputParameter` -> `WorkflowInputParameter`)
-  - Don't forget to catch all references of cwlgen, as missing one will cause:
+  - Don't forget to catch all references of cwlgen, as missing one (or using mismatch versions of the parser) will cause:
   
     ```python
     raise RepresenterError('cannot represent an object: %s' % (data,))

--- a/cwlgen/__init__.py
+++ b/cwlgen/__init__.py
@@ -2,6 +2,16 @@
 Library to handle the manipulation and generation of CWL tool
 '''
 
+import warnings
+
+warnings.warn(
+    "The cwlgen module is deprecated, please use "
+    "cwl-utils >= 0.4: https://github.com/common-workflow-language/cwl-utils",
+    DeprecationWarning,
+    stacklevel=2
+)
+
+
 #  Import  ------------------------------
 
 # General libraries

--- a/doc/source/classes.rst
+++ b/doc/source/classes.rst
@@ -26,10 +26,10 @@ This is the (abstract) base requirement class.
     :special-members:
     :exclude-members: __weakref__
 
-InlineJavascriptReq
-"""""""""""""""""""
+InlineJavascriptRequirement
+"""""""""""""""""""""""""""
 
-.. autoclass:: cwlgen.InlineJavascriptReq
+.. autoclass:: cwlgen.InlineJavascriptRequirement
     :members:
     :private-members:
     :special-members:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,8 +83,8 @@ You can install Python-CWLGen through pip with the following command:
 The classes very closely (if not exactly) mirror the CWL v1.0 specification. You can find
 more about their parameters in the following specifications:
 
-- :class:``cwlgen.CommandLineTool``
-- :class:``cwlgen.Workflow``
+- :class:`cwlgen.CommandLineTool`
+- :class:`cwlgen.Workflow`
 
 
 Python-cwlgen
@@ -110,6 +110,6 @@ Python-cwlgen API documentation
   Indices and tables
   ==================
 
-  * :ref:``genindex``
-  * :ref:``modindex``
-  * :ref:``search``
+  * :ref:`genindex`
+  * :ref:`modindex`
+  * :ref:`search`

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,8 +1,53 @@
 .. python-cwlgen - Python library for manipulation and generation of CWL tools.
 
 
-Welcome to python-cwlgen's documentation!
+Python-CWLGen (**Deprecated**)
 =========================================
+
+.. warning::
+
+   ``python-cwlgen`` is now deprecated, please use `cwl-utils >= 0.4 <https://github.com/common-workflow-language/cwl-utils>`_.
+
+Example migration:
+
+.. code-block:: bash
+
+   from cwl_utils import parser_v1_0
+   
+   # You could alias this as cwlgen to simplify the migration
+   from cwl_utils import parser_v1_0 as cwlgen
+
+
+Migration notes:
++++++++++++++++++++++
+
+- Method changes
+
+  - ``get_dict() → save()`` 
+  - ``parse_cwl(cwlfile)`` → ``load_document(cwlfile)``
+  - ``parse_dict`` → No super clear analogue, but loaded through ``_RecordLoader(CommandLineTool)`` || ``_UnionLoader((CommandLineToolLoader, ...workflow + other loaders)``
+
+- Field names:
+
+  - Uses ``camelCase`` instead of ``snake_case``
+  - No more special field names, eg:
+    - ``tool_id`` | ``workflow_id`` | ``input_id`` | etc → ``id``
+    - ``StepInput``: ``inputs`` → ``in_``
+    
+- Other notes:
+
+  - Classes aren't nested anymore, ie: ``cwlgen.InitialWorkDirRequirement.Dirent`` → ``cwlutils``.
+  - Take care if you're migrating to a newer spec, as some classes might have changed names (notably: ``InputParameter`` -> ``WorkflowInputParameter``)
+  - Don't forget to catch all references of cwlgen, as missing one (or using mismatch versions of the parser) will cause:
+  
+    .. code-block:: python
+
+       raise RepresenterError('cannot represent an object: %s' % (data,))
+       ruamel.yaml.representer.RepresenterError: cannot represent an object:
+       <cwlgen.common.CommandInputArraySchema object at 0x1100a5780>
+
+If you have issues with the migration, please see `this thread <https://github.com/common-workflow-language/python-cwlgen/issues/27>`_ or raise an issue on CWLUtils.
+    
 
 .. image:: https://travis-ci.org/common-workflow-language/python-cwlgen.svg?branch=master&style=flat
     :target: https://travis-ci.org/common-workflow-language/python-cwlgen
@@ -38,8 +83,8 @@ You can install Python-CWLGen through pip with the following command:
 The classes very closely (if not exactly) mirror the CWL v1.0 specification. You can find
 more about their parameters in the following specifications:
 
-- :class:`cwlgen.CommandLineTool`
-- :class:`cwlgen.Workflow`
+- :class:``cwlgen.CommandLineTool``
+- :class:``cwlgen.Workflow``
 
 
 Python-cwlgen
@@ -65,6 +110,6 @@ Python-cwlgen API documentation
   Indices and tables
   ==================
 
-  * :ref:`genindex`
-  * :ref:`modindex`
-  * :ref:`search`
+  * :ref:``genindex``
+  * :ref:``modindex``
+  * :ref:``search``


### PR DESCRIPTION
Closes https://github.com/common-workflow-language/python-cwlgen/issues/27 and [2020-05-26 EMEA-Americas Common Workflow Language meeting notes](https://docs.google.com/document/d/1Xd5keACw07z_3rbfTJNpeLvmTXudUPhksW57RopWwKU/edit?ts=5ecd261f#bookmark=id.65bk4y26ba9h).

This project is intended to be deprecated, and this PR makes suitable changes to the docs and repository to action this. It relies on the 0.4 release of cwl_utils which will release the new python API classes generated from the grammar.